### PR TITLE
AsciiDoc configuration improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,1 @@
+// This file intentionally left blank

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/introduction-to-serenity-with-cucumber/build.gradle
+++ b/introduction-to-serenity-with-cucumber/build.gradle
@@ -4,13 +4,15 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.0'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
     }
 }
 
-apply plugin: 'org.asciidoctor.gradle.asciidoctor'
+apply plugin: 'org.asciidoctor.convert'
 
-version="1.0.1"
+version='1.0.1'
 
 asciidoctor {
+  sourceDir 'src/asciidoc'
+  separateOutputDirs false
 }

--- a/introduction-to-serenity-with-cucumber/src/asciidoc/an-introduction-to-serenity-bdd-with-cucumber.asc
+++ b/introduction-to-serenity-with-cucumber/src/asciidoc/an-introduction-to-serenity-bdd-with-cucumber.asc
@@ -1,8 +1,7 @@
-An Introduction to BDD Test Automation with Serenity and Cucumber-JVM
-=====================================================================
-John Ferguson Smart @wakaleo
+= An Introduction to BDD Test Automation with Serenity and Cucumber-JVM
+John Ferguson Smart <https://twitter.com/wakaleo[@wakaleo]>
+ifdef::project-version[:revnumber: {project-version}]
 :lang: en
-:encoding: 'iso-8859-1'
 :keywords: serenity-bdd, cucumber, bdd, reference, learn, how to
 :doctype: article
 :compat-mode:

--- a/introduction-to-serenity-with-junit/build.gradle
+++ b/introduction-to-serenity-with-junit/build.gradle
@@ -4,13 +4,15 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.0'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
     }
 }
 
-apply plugin: 'org.asciidoctor.gradle.asciidoctor'
+apply plugin: 'org.asciidoctor.convert'
 
-version="1.0.1"
+version='1.0.1'
 
 asciidoctor {
+  sourceDir 'src/asciidoc'
+  separateOutputDirs false
 }

--- a/introduction-to-serenity-with-junit/src/asciidoc/an-introduction-to-serenity-bdd-with-junit.asc
+++ b/introduction-to-serenity-with-junit/src/asciidoc/an-introduction-to-serenity-bdd-with-junit.asc
@@ -1,8 +1,7 @@
-An Introduction to BDD Test Automation with Serenity and JUnit
-==============================================================
-John Ferguson Smart @wakaleo
+= An Introduction to BDD Test Automation with Serenity and JUnit
+John Ferguson Smart <https://twitter.com/wakaleo[@wakaleo]>
+ifdef::project-version[:revnumber: {project-version}]
 :lang: en
-:encoding: 'iso-8859-1'
 :keywords: serenity-bdd, bdd, reference, learn, how to
 :doctype: article
 :compat-mode:


### PR DESCRIPTION
- Upgrade Asciidoctor Gradle plugin to 1.5.2
- Upgrade Gradle to 2.2.1
- Add blank build.gradle file to avoid warnings
- fix AsciiDoc document headers
- remove encoding attribute
